### PR TITLE
Implement error notification for LLM interactions and update version …

### DIFF
--- a/lib/langgraph_rb/chat_openai.rb
+++ b/lib/langgraph_rb/chat_openai.rb
@@ -77,7 +77,13 @@ module LangGraphRB
       else
         text_content
       end
+    rescue => e
+      notify_llm_error({
+        error: e.message
+      })
+      raise e
     end
+
 
     private
 

--- a/lib/langgraph_rb/llm_base.rb
+++ b/lib/langgraph_rb/llm_base.rb
@@ -54,6 +54,16 @@ module LangGraphRB
         end
       end
     end
+
+    def notify_llm_error(payload)
+      @observers.each do |observer|
+        begin
+          observer.on_llm_error(payload, @node_name)
+        rescue => _e
+          # Ignore observer errors
+        end
+      end
+    end
   end
 end
 

--- a/lib/langgraph_rb/observers/base.rb
+++ b/lib/langgraph_rb/observers/base.rb
@@ -70,6 +70,10 @@ module LangGraphRB
         # Override in subclasses
       end
 
+      def on_llm_error(event)
+        # Override in subclasses
+      end
+
       protected
 
       # Helper method to create standardized event structure

--- a/lib/langgraph_rb/version.rb
+++ b/lib/langgraph_rb/version.rb
@@ -1,3 +1,3 @@
 module LangGraphRB
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end 


### PR DESCRIPTION
…to 0.1.7

- Added error handling in `chat_openai.rb` to notify observers of LLM errors.
- Introduced `notify_llm_error` method in `llm_base.rb` to facilitate error reporting.
- Updated `on_llm_error` method in `langfuse.rb` to handle error data and update generation records.
- Bumped version number in `version.rb` to 0.1.7.