### PR TITLE
Remove OpenAI dependency and introduce ChatRubyOpenAI class for enhan…

### DIFF
--- a/langgraph_rb.gemspec
+++ b/langgraph_rb.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency "json", "~> 2.0"
-  spec.add_dependency "openai", "~> 0.24.0"
 
   # Development dependencies
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/langgraph_rb.rb
+++ b/lib/langgraph_rb.rb
@@ -11,7 +11,6 @@ require_relative 'langgraph_rb/observers/logger'
 require_relative 'langgraph_rb/observers/structured'
 require_relative 'langgraph_rb/observers/langfuse'
 require_relative 'langgraph_rb/llm_base'
-require_relative 'langgraph_rb/chat_openai'
 require_relative 'langgraph_rb/tool_definition'
 
 module LangGraphRB

--- a/lib/langgraph_rb/version.rb
+++ b/lib/langgraph_rb/version.rb
@@ -1,3 +1,3 @@
 module LangGraphRB
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end 


### PR DESCRIPTION
…ced OpenAI integration

- Removed the `openai` gem dependency from the gemspec.
- Refactored `ChatOpenAI` class to handle client initialization more flexibly.
- Added a new `ChatRubyOpenAI` class to support interactions with the `ruby-openai` gem, including error handling for missing dependencies.
- Updated version number to 0.1.8 in `version.rb` to reflect changes.